### PR TITLE
Hide balance if single cell battery is selected

### DIFF
--- a/src/core/menus/ProgramMenus.cpp
+++ b/src/core/menus/ProgramMenus.cpp
@@ -52,6 +52,18 @@ namespace ProgramMenus {
             Program::EditBattery,
     };
 
+    const Program::ProgramType programLiXX1CellMenu[] PROGMEM = {
+            Program::Charge,
+            Program::Discharge,
+            Program::FastCharge,
+            Program::Storage,
+#ifdef ENABLE_PROGRAM_MENUS_LIXX_CYCLING
+            Program::DischargeChargeCycle,
+#endif
+            Program::CapacityCheck,
+            Program::EditBattery,
+    };
+
     const Program::ProgramType programNiZnMenu[] PROGMEM = {
             Program::Charge,
             Program::ChargeBalance,
@@ -109,8 +121,11 @@ namespace ProgramMenus {
             return programNoneMenu;
         if(bc == ProgramData::ClassNiZn)
             return programNiZnMenu;
-        if(bc == ProgramData::ClassLiXX)
+        if(bc == ProgramData::ClassLiXX) {
+            if (ProgramData::battery.cells == 1)
+                return programLiXX1CellMenu;
             return programLiXXMenu;
+        }
         if(bc == ProgramData::ClassNiXX)
             return programNiXXMenu;
         if(bc == ProgramData::ClassLED)


### PR DESCRIPTION
I tend to charge a single cell li-ion a lot, and the balance menu points are useless in these case.
This patch hides the balance and charge+balance menu items if a single cell li-xx battery is selected.

Tested on a Nuvotoun based iMax B6 clone.