### PR TITLE
README: add Redox Beta to supported chargers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Hardware
 - Turnigy Accucel-8 150W 7A Balancer/Charger
 - Turnigy MEGA 400Wx2 Battery Charger/Discharger (800W)
 - Thunder T610 Balance Charger/Discharger
+- Redox Beta 50W 5A charger (at least later model with yellow soldermask)
 - ... many more
 
 **Nuvoton NuMicro M0517LBN CPU:**


### PR DESCRIPTION
Add Redox Beta to list of supported chargers. Device is using the
typical "imaxb6-clone" configuration.

Only tested on newer revision with yellow soldermask.
Either soldering to CPU pins or replacing it with hot-air is required - it was possible to read out stock firmware.

There is an older revision of the charger with red soldermask and
programming port, but I haven't had a chance to get my hands on one,
yet.