### PR TITLE
Github Actions to build firmware

### DIFF
--- a/.github/workflows/atmega.yml
+++ b/.github/workflows/atmega.yml
@@ -1,4 +1,4 @@
-name: Build firmware
+name: Build firmware for Atmega
 
 on:
   push:

--- a/.github/workflows/atmega.yml
+++ b/.github/workflows/atmega.yml
@@ -6,12 +6,14 @@ on:
       - 'docs/**'
       - 'README.md'
       - 'src/hardware/nuvoton*/**'
+      - '.github/workflows/novuton.yml'
 
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'README.md'
       - 'src/hardware/nuvoton*/**'
+      - '.github/workflows/novuton.yml'
 
 jobs:
   build:

--- a/.github/workflows/atmega.yml
+++ b/.github/workflows/atmega.yml
@@ -2,7 +2,16 @@ name: Build firmware for Atmega
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/nuvoton*/**'
+
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/nuvoton*/**'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,8 @@ jobs:
           packages: cmake avr-libc gcc-avr git
           version: 1.0
       - uses: actions/checkout@v3
-#       - name: Install Dependencies
-#         run: | 
-#             sudo apt-get install cmake avr-libc gcc-avr git
-      - name: Prepare Env
+
+      - name: Build Project
         run: | 
             git submodule init
             git submodule update
@@ -27,5 +25,7 @@ jobs:
       - name: Upload Artifacts 
         uses: actions/upload-artifact@v3
         with:
+          name: atmega32
           path: | 
-                src/hardware/atmega32/targets/**
+                src/hardware/atmega32/targets/*.hex
+                src/hardware/atmega32/targets/*.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: | 
-                src/hardware/atmega32/targets/**/progUSBasp.sh
-                src/hardware/atmega32/targets/**/**.hex
+                src/hardware/atmega32/targets/**

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: | 
-                src/hardware/atmega32/targets/**/*.hex
                 src/hardware/atmega32/targets/**/progUSBasp.sh
+                src/hardware/atmega32/targets/**/**.hex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Upload Artifacts 
         uses: actions/upload-artifact@v3
         with:
-          name: firmwares.tar.gz
           path: | 
                 src/hardware/atmega32/targets/**/*.hex
                 src/hardware/atmega32/targets/**/progUSBasp.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           name: atmega32
           path: | 
-                src/hardware/atmega32/targets/*.hex
+                src/hardware/atmega32/targets/**/*.hex
                 
       - name: Upload Artifacts 
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+ # This is a basic workflow to help you get started with Actions
+
+name: Build firmware
+
+# Controls when the action will run. 
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+      - name: Prepare Env
+        run: | 
+            sudo apt-get install cmake avrdude avr-libc gcc-avr git
+            git clone https://github.com/stawel/cheali-charger.git
+            cd cheali-charger
+            git submodule init
+            git submodule update
+            ./bootstrap-avr
+            make
+      
+#       - name: Build Submodules
+#         run: |    
+#             ./scripts/compile_ci_pre.sh
+
+#       - name: Build stuff
+#         run: |    
+#             ./scripts/compile_ci_post.sh
+
+#       - name: Pack stuff
+#         run: |    
+#             sudo ./scripts/pack_fw.all.sh
+#             ls -la
+#             pwd           
+            
+#       - name: Upload Artifact GK-200MP2B
+#         uses: actions/upload-artifact@v2
+#         with:
+#           name: GK-200MP2B.tar.gz
+#           path: out/GK-200MP2B/**.tgz
+
+#       - name: Upload Artifact GK-200MP2C
+#         uses: actions/upload-artifact@v2
+#         with:
+#           name: GK-200MP2C.tar.gz
+#           path: out/GK-200MP2C/**.tgz%    

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,11 @@ jobs:
       - name: Prepare Env
         run: | 
             sudo apt-get install cmake avrdude avr-libc gcc-avr git
-            git clone https://github.com/stawel/cheali-charger.git
             cd cheali-charger
             git submodule init
             git submodule update
             ./bootstrap-avr
-            make       
+            make
             
       - name: Upload Artifacts 
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,15 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      
+      - name: Install Dependencies
+        run: | 
+            sudo apt-get install cmake avr-libc gcc-avr git
+      
       - name: Prepare Env
         run: | 
-            sudo apt-get install cmake avrdude avr-libc gcc-avr git
+            ls -la
             cd cheali-charger
             git submodule init
             git submodule update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,10 @@ jobs:
           name: atmega32
           path: | 
                 src/hardware/atmega32/targets/*.hex
-                src/hardware/atmega32/targets/*.sh
+                
+      - name: Upload Artifacts 
+        uses: actions/upload-artifact@v3
+        with:
+          name: progUSBasp
+          path: | 
+                src/hardware/atmega32/targets/ADCKeyboardAnalyzer-150W/progUSBasp.sh            

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,4 @@ jobs:
           name: atmega32
           path: | 
                 src/hardware/atmega32/targets/**/*.hex
-                
-      - name: Upload Artifacts 
-        uses: actions/upload-artifact@v3
-        with:
-          name: progUSBasp
-          path: | 
-                src/hardware/atmega32/targets/ADCKeyboardAnalyzer-150W/progUSBasp.sh            
+                src/hardware/atmega32/targets/**/progUSBasp.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: cmake avr-libc gcc-avr git
+          version: 1.0
       - uses: actions/checkout@v3
-      
-      - name: Install Dependencies
-        run: | 
-            sudo apt-get install cmake avr-libc gcc-avr git
-      
+#       - name: Install Dependencies
+#         run: | 
+#             sudo apt-get install cmake avr-libc gcc-avr git
       - name: Prepare Env
         run: | 
-            ls -la
-            cd cheali-charger
             git submodule init
             git submodule update
             ./bootstrap-avr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
- # This is a basic workflow to help you get started with Actions
-
 name: Build firmware
 
-# Controls when the action will run. 
 on:
   push:
   pull_request:
@@ -22,30 +19,12 @@ jobs:
             git submodule init
             git submodule update
             ./bootstrap-avr
-            make
-      
-#       - name: Build Submodules
-#         run: |    
-#             ./scripts/compile_ci_pre.sh
-
-#       - name: Build stuff
-#         run: |    
-#             ./scripts/compile_ci_post.sh
-
-#       - name: Pack stuff
-#         run: |    
-#             sudo ./scripts/pack_fw.all.sh
-#             ls -la
-#             pwd           
+            make       
             
-#       - name: Upload Artifact GK-200MP2B
-#         uses: actions/upload-artifact@v2
-#         with:
-#           name: GK-200MP2B.tar.gz
-#           path: out/GK-200MP2B/**.tgz
-
-#       - name: Upload Artifact GK-200MP2C
-#         uses: actions/upload-artifact@v2
-#         with:
-#           name: GK-200MP2C.tar.gz
-#           path: out/GK-200MP2C/**.tgz%    
+      - name: Upload Artifacts 
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmwares.tar.gz
+          path: | 
+                src/hardware/atmega32/targets/**/*.hex
+                src/hardware/atmega32/targets/**/progUSBasp.sh

--- a/.github/workflows/novuton.yml
+++ b/.github/workflows/novuton.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
       - 'README.md'
       - 'src/hardware/atmega32/**'
-      
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: git cmake openocd
+          packages: git cmake openocd gcc-arm-none-eabi 
           version: 1.0
       - uses: actions/checkout@v3
 

--- a/.github/workflows/novuton.yml
+++ b/.github/workflows/novuton.yml
@@ -6,12 +6,14 @@ on:
       - 'docs/**'
       - 'README.md'
       - 'src/hardware/atmega32/**'
+      - '.github/workflows/atmega.yml'
 
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'README.md'
       - 'src/hardware/atmega32/**'
+      - '.github/workflows/atmega.yml'
 
 jobs:
   build:

--- a/.github/workflows/novuton.yml
+++ b/.github/workflows/novuton.yml
@@ -20,10 +20,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: git cmake openocd gcc-arm-none-eabi 
-          version: 1.0
+      # - uses: awalsh128/cache-apt-pkgs-action@latest
+      #   with:
+      #     packages: git cmake openocd gcc-arm-none-eabi 
+      #     version: 1.0
+      
+      - name: Install Packages old way
+        run: | 
+            sudo apt-get install -y git cmake openocd gcc-arm-none-eabi 
+
       - uses: actions/checkout@v3
 
       - name: Build Project

--- a/.github/workflows/novuton.yml
+++ b/.github/workflows/novuton.yml
@@ -31,10 +31,16 @@ jobs:
             ./bootstrap-arm
             make
             
+      - name: Print contents
+        run: | 
+            ls -la src/hardware/
+            find src/hardware
+
+
       - name: Upload Artifacts 
         uses: actions/upload-artifact@v3
         with:
           name: novuton
           path: | 
-                src/hardware/nuvoton-M0517/targets/**/*.hex
-                src/hardware/nuvoton-M0517/targets/**/progStLink*.sh
+                src/hardware/nuvoton**/targets/**/*.hex
+                src/hardware/nuvoton**/targets/**/progStLink*.sh

--- a/.github/workflows/novuton.yml
+++ b/.github/workflows/novuton.yml
@@ -2,8 +2,17 @@ name: Build firmware for Nuvoton
 
 on:
   push:
-  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/atmega32/**'
 
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/atmega32/**'
+      
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/novuton.yml
+++ b/.github/workflows/novuton.yml
@@ -1,0 +1,31 @@
+name: Build firmware for Nuvoton
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: git cmake openocd
+          version: 1.0
+      - uses: actions/checkout@v3
+
+      - name: Build Project
+        run: | 
+            git submodule init
+            git submodule update
+            ./bootstrap-arm
+            make
+            
+      - name: Upload Artifacts 
+        uses: actions/upload-artifact@v3
+        with:
+          name: novuton
+          path: | 
+                src/hardware/nuvoton-M0517/targets/**/*.hex
+                src/hardware/nuvoton-M0517/targets/**/progStLink*.sh


### PR DESCRIPTION
This allows to build firmware using Github actions.
Exposes artifacts that contains .hex file & build scripts.
Example of artifacts is in:
https://github.com/shafr/cheali-charger/actions