### PR TITLE
Github Actions to build firmware

### DIFF
--- a/.github/workflows/atmega.yml
+++ b/.github/workflows/atmega.yml
@@ -1,0 +1,42 @@
+name: Build firmware for Atmega
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/nuvoton*/**'
+      - '.github/workflows/novuton.yml'
+
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/nuvoton*/**'
+      - '.github/workflows/novuton.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Packages 
+        run: | 
+            sudo apt-get install -y cmake avr-libc gcc-avr git
+            
+      - uses: actions/checkout@v3
+
+      - name: Build Project
+        run: | 
+            git submodule init
+            git submodule update
+            ./bootstrap-avr
+            make
+            
+      - name: Upload Artifacts 
+        uses: actions/upload-artifact@v3
+        with:
+          name: atmega32
+          path: | 
+                src/hardware/atmega32/targets/**/*.hex
+                src/hardware/atmega32/targets/**/progUSBasp.sh

--- a/.github/workflows/novuton.yml
+++ b/.github/workflows/novuton.yml
@@ -1,0 +1,48 @@
+name: Build firmware for Nuvoton
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/atmega32/**'
+      - '.github/workflows/atmega.yml'
+
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'src/hardware/atmega32/**'
+      - '.github/workflows/atmega.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:    
+      - name: Install Packages
+        run: | 
+            sudo apt-get install -y git cmake openocd gcc-arm-none-eabi 
+
+      - uses: actions/checkout@v3
+
+      - name: Build Project
+        run: | 
+            git submodule init
+            git submodule update
+            ./bootstrap-arm
+            make
+            
+      - name: Print contents
+        run: | 
+            ls -la src/hardware/
+            find src/hardware
+
+
+      - name: Upload Artifacts 
+        uses: actions/upload-artifact@v3
+        with:
+          name: novuton
+          path: | 
+                src/hardware/nuvoton**/targets/**/*.hex
+                src/hardware/nuvoton**/targets/**/progStLink*.sh


### PR DESCRIPTION
This allows to build firmware using Github actions.
Exposes artifacts that contains .hex file & build scripts.
Example of artifacts is in:
https://github.com/shafr/cheali-charger/actions